### PR TITLE
New revdiff mode, minor color corrections

### DIFF
--- a/revdiff.sty
+++ b/revdiff.sty
@@ -72,6 +72,31 @@
 
 
 %================================================%
+% Declare options - new mode
+%================================================%
+
+\DeclareOption{new}{
+
+  \renewcommand{\rnew}[1]{\textcolor{newcolor}{#1}}
+  \renewcommand{\rold}[1]{\textcolor{oldcolor}{[\ldots]}}
+  \renewcommand{\rchange}[2]{\rnew{#2}}
+  \renewcommand{\rtag}[1]{}
+  \renewcommand{\rcomment}[1]{}
+  \renewcommand{\renclose}[2]{#2}
+  
+  \renewcommand{\rtchange}[3]{\rchange{#2}{#3}}
+  \renewcommand{\rtcomment}[2]{\rcomment{#2}}
+  \renewcommand{\rtenclose}[3]{\renclose{#2}{#3}}
+  
+  % cite needs to be redefined to avoid compilation errors
+  %\renewcommand{\cite}[1]{\origcite{#1}}
+  
+  % this command prints a legend 
+  \renewcommand{\rlegend}{}
+}
+
+
+%================================================%
 % Declare options - clean mode
 %================================================%
 

--- a/revdiff.sty
+++ b/revdiff.sty
@@ -11,9 +11,9 @@
 \RequirePackage{tikz}
 \RequirePackage[normalem]{ulem}
 
-\definecolor{newcolor}{RGB}{0,0,153}
-\definecolor{oldcolor}{RGB}{255,102,102}
-\definecolor{tagcolor}{RGB}{255,128,0}
+\definecolor{newcolor}{RGB}{0,0,240}
+\definecolor{oldcolor}{RGB}{253,102,102}
+\definecolor{tagcolor}{RGB}{253,128,0}
 \definecolor{commentcolor}{RGB}{0,153,0}
 
 \newcommand{\rnew}[1]{#1}


### PR DESCRIPTION
Hi Pedro,
not sure if you intend to maintain this further and if you're interested in these changes - I found the package very useful, but I got color overflow errors so I changed the colors a little bit. I also made the blue a bit brighter, as the dark blue will not contrast well enough with black on a laser printer.
The more significant addition is the "new" mode, which highlights new text in blue and displays old stuff with a red "[...]" instead of the full text, which results in a layout that is closer to the final version as it doesn't use up as much space. I found this easier for proof-reading than the full revision mode.
Johannes